### PR TITLE
incorrect link to source rpms

### DIFF
--- a/download.html
+++ b/download.html
@@ -62,7 +62,7 @@ You can clone a copy with
 
 <h3><a name="lists">Source RPMs</a></h3>
 
-<p>Source RPMs can be found at the same location as our binaries. Older source RPMs (pre Spacewalk 1.8) can be found <a href="./source/">here</a>.</p>
+<p>Source RPMs can be found at the same location as our binaries. Older source RPMs (pre Spacewalk 1.8) can be found <a href="http://spacewalkproject.org/source/">here</a>.</p>
 
 <h3><a name="lists">Binary RPMs</a></h3>
 


### PR DESCRIPTION
correct link to source rpms http://spacewalkproject.org/source/